### PR TITLE
fix(zcash): use correct Canopy consensus branch id for BitcoinZ (0xe9ff75a6)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@runonflux/bitgo-utxo-lib",
-  "version": "9.39.1",
+  "version": "9.39.2",
   "description": "Client-side Bitcoin JavaScript library",
   "main": "./dist/src/index.js",
   "engines": {

--- a/src/bitgo/zcash/ZcashTransaction.ts
+++ b/src/bitgo/zcash/ZcashTransaction.ts
@@ -80,6 +80,11 @@ export function getDefaultConsensusBranchIdForVersion(network: ZcashNetwork, ver
     case ZcashTransaction.VERSION4_BRANCH_CANOPY:
       // https://zips.z.cash/zip-0251
       switch (network) {
+        case networks.bitcoinz:
+          // BitcoinZ uses the standard Zcash Canopy consensus branch id
+          // (0xe9ff75a6), NOT the Komodo/Flux family value (0x76b809bb).
+          // Canopy activated on BTCZ mainnet at height 1,735,000 (~Mar 2026).
+          return CANOPY_BRANCH_ID;
         case networks.komodo:
         case networks.safecoin:
         case networks.zelcash:
@@ -87,7 +92,6 @@ export function getDefaultConsensusBranchIdForVersion(network: ZcashNetwork, ver
         case networks.snowgem:
         case networks.gemlink:
         case networks.commercium:
-        case networks.bitcoinz:
         case networks.fluxtestnet:
         case networks.hush:
           return 0x76b809bb;
@@ -110,6 +114,11 @@ export function getDefaultConsensusBranchIdForVersion(network: ZcashNetwork, ver
     case ZcashTransaction.VERSION5_BRANCH_NU6_2:
       // https://zips.z.cash/zip-0252
       switch (network) {
+        case networks.bitcoinz:
+          // BitcoinZ uses the standard Zcash Canopy consensus branch id
+          // (0xe9ff75a6), NOT the Komodo/Flux family value (0x76b809bb).
+          // Canopy activated on BTCZ mainnet at height 1,735,000 (~Mar 2026).
+          return CANOPY_BRANCH_ID;
         case networks.komodo:
         case networks.safecoin:
         case networks.zelcash:
@@ -117,7 +126,6 @@ export function getDefaultConsensusBranchIdForVersion(network: ZcashNetwork, ver
         case networks.snowgem:
         case networks.gemlink:
         case networks.commercium:
-        case networks.bitcoinz:
         case networks.fluxtestnet:
         case networks.hush:
           return 0x76b809bb;


### PR DESCRIPTION
## Problem

BitcoinZ activated the **Canopy** network upgrade on mainnet at block height **1,735,000 (~March 2026)**. Post-Canopy, the BTCZ network requires consensus branch id **`0xe9ff75a6`** — the standard Zcash Canopy id, which BitcoinZ reuses.

`getDefaultConsensusBranchIdForVersion()` incorrectly grouped `bitcoinz` with the Komodo/Flux family (`0x76b809bb`). The branch id is mixed into the BLAKE2b sighash personalization (`"ZcashSigHash" + LE(branchId)`), so **every v4 BitcoinZ transaction was signed with the wrong branch id**, producing invalid signatures. Nodes reject them with:

```
-26 mandatory-script-verify-flag-failed
Script evaluated without error but finished with a false/empty top stack element
```

This breaks **all** BitcoinZ transparent sends since Canopy activated.

## Fix

Give `bitcoinz` its own `case` returning `CANOPY_BRANCH_ID` (`0xe9ff75a6`) in both the `VERSION4_BRANCH_CANOPY` switch and the `case 4`/NU switch. Removed it from the shared `0x76b809bb` fall-through.

**Scope is bitcoinz-only.** The Komodo/Flux group (`zelcash`, `flux`, `komodo`, `hush`, `snowgem`, `gemlink`, `commercium`, `safecoin`) keeps `0x76b809bb` — their values were not verified here and are unchanged. `bitcoinz` v3 (Overwinter, `0x5ba81b19`) is also unchanged.

## Verification

Verified against **two real, network-accepted post-Canopy on-chain BTCZ transparent P2PKH spends**:
- height **1,737,096** (just after Canopy)
- height **1,783,418** (current epoch, ~June 2026)

Both signatures verify **only** under `0xe9ff75a6` — never `0x76b809bb` or `0x5ba81b19`. After the fix, a freshly-built v4 BTCZ transaction signs with `0xe9ff75a6` and the produced signature is valid under the network-required branch id.

Per-coin output after the fix (version 4):
| coin | branch id | |
|---|---|---|
| bitcoinz | `0xe9ff75a6` | fixed |
| zelcash / flux / komodo / hush / snowgem / gemlink / commercium / safecoin | `0x76b809bb` | unchanged |
| zcash | `0x5437f330` | unchanged |